### PR TITLE
Add precombat cast for Sigil of Flame

### DIFF
--- a/engine/class_modules/apl/demon_hunter/havoc.simc
+++ b/engine/class_modules/apl/demon_hunter/havoc.simc
@@ -11,7 +11,8 @@ actions.precombat+=/arcane_torrent
 # Executed every time the actor is available.
 actions=auto_attack
 actions+=/retarget_auto_attack,line_cd=1,target_if=min:debuff.burning_wound.remains,if=talent.burning_wound&talent.demon_blades&active_dot.burning_wound<(spell_targets>?3)
-# Precombat Immolation Aura
+# Precombat Sigil of Flame & Immolation Aura
+actions+=/sigil_of_flame,if=time=0
 actions+=/immolation_aura,if=time=0
 # Blade Dance with First Blood, Trail of Ruin, or at 2+ targets
 actions+=/variable,name=blade_dance,value=talent.first_blood|talent.trail_of_ruin|talent.chaos_theory&buff.chaos_theory.down|spell_targets.blade_dance1>1


### PR DESCRIPTION
Generates more fury than Immolation aura, wastes 1 less tick that could be used to build ragefire (if taken) and starts the fight with the DoT. 

Both spells can be cast before combat begins due to the detonation time of Sigil of Flame.